### PR TITLE
fix: wrong call to `path.join`

### DIFF
--- a/packages/cli/commands/publish.mjs
+++ b/packages/cli/commands/publish.mjs
@@ -15,7 +15,7 @@ const publish = () => {
     name: packageInfo.name,
     version: packageInfo.version,
     description: packageInfo.description,
-    tarballPath: path.join(modulesRoot, tarballFilename),
+    tarballPath: join(modulesRoot, tarballFilename),
   };
 
   fs.writeFileSync(packagesInfoPath, JSON.stringify(packagesInfo, null, 2));


### PR DESCRIPTION
Fix wrong call to `path.join` in publish command