### PR TITLE
Add alias `i` to install command

### DIFF
--- a/packages/cli/commands/install.mjs
+++ b/packages/cli/commands/install.mjs
@@ -18,6 +18,7 @@ const install = (packageName) => {
 };
 
 export const command = 'install <packageName>';
+export const aliases = ['i'];
 export const desc = 'Install a package from the local registry';
 export const builder = {};
 export const handler = (argv) => install(argv.packageName);


### PR DESCRIPTION
Add alias `i` to install command
### Usage
```bash
loctry i <package-name>
# or
loctry install <package-name>
```